### PR TITLE
♻️ Refac: Major refactor menu and MRU.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,10 @@ add_executable(Aegisub WIN32
     src/autoreghook.cpp
     #src/auidemo.cpp
     src/main_toolbar.cpp
+    src/menu_builtin.cpp
+    src/menu_dynamic_builtin.cpp
+    src/menu_dynamic.cpp
+    src/mru_builtin.cpp
 )
 
 target_link_libraries(Aegisub ${CMAKE_DL_LIBS} libaegisub)

--- a/libaegisub/common/id_allocator.cpp
+++ b/libaegisub/common/id_allocator.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2020, Charlie Jiang <cqjjjzr@126.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#include "libaegisub/id_allocator.h"
+
+namespace agi {
+id_allocator::id_allocator(int minId, int maxId)
+{
+    free_intervals.emplace(minId, maxId);
+    limit = id_interval(minId, maxId);
+}
+
+int id_allocator::allocate()
+{
+    id_interval first = *(free_intervals.begin());
+    int free_id = first.left();
+    free_intervals.erase(free_intervals.begin());
+    if (first.left() + 1 <= first.right())
+        free_intervals.emplace(first.left() + 1, first.right());
+    return free_id;
+}
+
+void id_allocator::free(int id)
+{
+    auto after = free_intervals.upper_bound(id_interval(id, id));
+    auto before = after;
+    auto has_after = after != free_intervals.end();
+    auto has_before = before != free_intervals.begin();
+    if (has_before) {
+        --before; // Move before to the real `before`
+        if (before->is_in(id)) return; // Already free!
+    }
+
+    auto after_linkable = has_after && after->left() == id + 1;
+    auto before_linkable = has_before && before->right() == id - 1;
+
+    if (before_linkable && after_linkable)
+    {
+        int l = before->left(), r = after->right();
+        auto temp = after;
+        if (has_after) ++temp;
+        free_intervals.erase(after);
+        free_intervals.erase(before);
+        if (temp != free_intervals.end())
+            free_intervals.emplace_hint(temp, l, r);
+        else
+            free_intervals.emplace(l, r);
+        return;
+    }
+    if (before_linkable)
+    {
+        int l = before->left(), r = id;
+        free_intervals.erase(before);
+        if (has_after)
+            free_intervals.emplace_hint(after, l, r);
+        else
+            free_intervals.emplace(l, r);
+        return;
+    }
+    if (after_linkable)
+    {
+        int l = id, r = after->right();
+        free_intervals.erase(after);
+        if (has_before)
+            free_intervals.emplace_hint(before, l, r);
+        else
+            free_intervals.emplace(l, r);
+        return;
+    }
+
+    free_intervals.emplace(id, id);
+}
+}

--- a/libaegisub/include/libaegisub/format.h
+++ b/libaegisub/include/libaegisub/format.h
@@ -14,6 +14,8 @@
 //
 // Aegisub Project http://www.aegisub.org/
 
+#pragma once
+
 #include <libaegisub/fs_fwd.h>
 
 #include <boost/interprocess/streams/vectorstream.hpp>

--- a/libaegisub/include/libaegisub/id_allocator.h
+++ b/libaegisub/include/libaegisub/id_allocator.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2020, Charlie Jiang <cqjjjzr@126.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#pragma once
+
+#include <boost/numeric/interval.hpp>
+#include <set>
+#include <limits>
+
+namespace agi {
+
+class id_interval
+{
+public:
+    id_interval() : id_interval(0, 0) {}
+    id_interval(const int ll, const int uu) : value(ll, uu) {}
+    bool operator < (const id_interval& another) const { return value.upper() < another.value.lower(); }
+    [[nodiscard]] int left() const { return value.lower(); }
+    [[nodiscard]] int right() const { return value.upper(); }
+
+    [[nodiscard]] bool is_in(int id) const { return value.lower() >= id && value.upper() <= id; }
+private:
+    boost::numeric::interval<int> value;
+};
+
+class id_allocator {
+public:
+    id_allocator() : id_allocator(0, std::numeric_limits<int>::max()) {}
+    id_allocator(int minId, int maxId);
+    int allocate();          // Allocates an id
+    void free(int id);       // Frees an id so it can be used again
+
+    bool is_in(int id) const { return limit.is_in(id); }
+private:
+    using id_intervals_t = std::set<id_interval>;
+    id_intervals_t free_intervals;
+
+    id_interval limit;
+};
+
+}

--- a/libaegisub/libaegisub.cmake
+++ b/libaegisub/libaegisub.cmake
@@ -47,6 +47,7 @@ add_library(libaegisub STATIC
     libaegisub/common/ycbcr_conv.cpp
     libaegisub/common/dispatch.cpp
     libaegisub/common/resources_fs.cpp
+    libaegisub/common/id_allocator.cpp
 )
 
 if(UNIX)

--- a/src/base_grid.cpp
+++ b/src/base_grid.cpp
@@ -32,6 +32,7 @@
 #include "include/aegisub/context.h"
 #include "include/aegisub/hotkey.h"
 #include "include/aegisub/menu.h"
+#include "include/aegisub/menu_initializer.h"
 
 #include "ass_dialogue.h"
 #include "ass_file.h"
@@ -54,6 +55,11 @@
 #include <wx/menu.h>
 #include <wx/scrolbar.h>
 #include <wx/sizer.h>
+
+namespace menu {
+extern agi::id_allocator* builtinAllocator;
+}
+std::vector<menu::MenuNode> GetGridContextMenu(agi::Context*);
 
 enum {
 	GRID_SCROLLBAR = 1730,
@@ -541,7 +547,7 @@ void BaseGrid::OnMouseEvent(wxMouseEvent &event) {
 void BaseGrid::OnContextMenu(wxContextMenuEvent &evt) {
 	wxPoint pos = evt.GetPosition();
 	if (pos == wxDefaultPosition || ScreenToClient(pos).y > lineHeight) {
-		if (!context_menu) context_menu = menu::GetMenu("grid_context", context);
+		if (!context_menu) context_menu = menu::GetMenu(GetGridContextMenu, context, menu::builtinAllocator);
 		menu::OpenPopupMenu(context_menu.get(), this);
 	}
 	else {

--- a/src/command/command.h
+++ b/src/command/command.h
@@ -16,6 +16,8 @@
 /// @brief Command base class and main header.
 /// @ingroup command
 
+#pragma once
+
 #include <map>
 #include <string>
 #include <vector>

--- a/src/compat.cpp
+++ b/src/compat.cpp
@@ -35,3 +35,8 @@ agi::Color from_wx(wxColour color) {
 std::string from_wx(wxString const& str) {
 	return std::string(str.utf8_str());
 }
+
+std::string GetTranslation_std(std::string const& str)
+{
+	return from_wx(wxGetTranslation(to_wx(str)));
+}

--- a/src/compat.h
+++ b/src/compat.h
@@ -16,4 +16,6 @@ wxArrayString to_wx(std::vector<std::string> const& vec);
 agi::Color from_wx(wxColour color);
 std::string from_wx(wxString const& str);
 
+std::string GetTranslation_std(std::string const& str);
+
 wxArrayString lagi_MRU_wxAS(const char *list);

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -37,6 +37,7 @@
 #include "include/aegisub/menu.h"
 #include "include/aegisub/toolbar.h"
 #include "include/aegisub/hotkey.h"
+#include "include/aegisub/menu_initializer.h"
 
 #include "ass_file.h"
 #include "async_video_provider.h"
@@ -73,6 +74,11 @@
 enum {
 	ID_APP_TIMER_STATUSCLEAR = 12002
 };
+
+namespace menu {
+extern agi::id_allocator* builtinAllocator;
+}
+std::vector<menu::MenuNode> GetMainMenu(agi::Context*);
 
 #ifdef WITH_STARTUPLOG
 #define StartupLog(a) wxMessageBox(a, "Aegisub startup log")
@@ -133,7 +139,7 @@ FrameMain::FrameMain()
 	EnableToolBar(*OPT_GET("App/Show Toolbar"));
 
 	StartupLog("Initialize menu bar");
-	menu::GetMenuBar("main", this, context.get());
+	menu::AttachMenuBar(GetMainMenu, this, context.get(), menu::builtinAllocator);
 
 	StartupLog("Create status bar");
 	CreateStatusBar(2);

--- a/src/include/aegisub/menu_dynamic.h
+++ b/src/include/aegisub/menu_dynamic.h
@@ -1,0 +1,178 @@
+// Copyright (c) 2020, Charlie Jiang <cqjjjzr@126.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#pragma once
+
+#include "compat.h"
+
+#include "command/command.h"
+#include <wx/control.h>
+#include <libaegisub/signal.h>
+
+namespace agi
+{
+struct Context;
+class id_allocator;
+}
+
+enum MenuItemType
+{
+	MENU_NORMAL = 0,
+
+	/// Invoking this command toggles a setting of some sort. Any command
+	/// of this type should have IsActive implemented to signal the
+	/// current state of the thing being toggled, and invoking the command
+	/// twice should be a no-op
+	///
+	/// This is mutually exclusive with MENU_RADIO
+	MENU_TOGGLE = 1,
+
+	/// Invoking this command sets a setting to a specific value. Any
+	/// command of this type should have IsActive implemented, and if
+	/// IsActive returns true, invoking the command should have no effect
+	///
+	/// This is mutually exclusive with MENU_TOGGLE
+	MENU_RADIO = 2
+};
+
+class DynamicMenuItem
+{
+public:
+    virtual ~DynamicMenuItem() = default;
+    virtual wxString GetDisplayName(agi::Context*) = 0;
+	virtual wxString GetHotkeyText(agi::Context*) = 0;
+	virtual wxString GetHelp(agi::Context*) = 0;
+	virtual wxBitmap GetIcon(int size, wxLayoutDirection dir = wxLayout_LeftToRight) { return wxBitmap{}; }
+	virtual bool Validate(agi::Context*) = 0;
+	virtual MenuItemType GetMenuItemType() = 0;
+	virtual bool IsDynamic() = 0;
+	virtual bool IsActive(agi::Context*) = 0;
+	virtual void OnClick(agi::Context*) = 0;
+};
+
+class MinimalDynamicMenuItem : public DynamicMenuItem
+{
+	std::function<void(agi::Context*)> func;
+public:
+	MinimalDynamicMenuItem(std::function<void(agi::Context*)> func): func(func){}
+	wxString GetDisplayName(agi::Context*) override { return ""; }
+	wxString GetHotkeyText(agi::Context*) override { return ""; }
+	wxString GetHelp(agi::Context*) override { return ""; }
+	bool Validate(agi::Context*) override { return true; }
+	MenuItemType GetMenuItemType() override { return MENU_NORMAL; }
+	bool IsDynamic() override { return false; }
+	bool IsActive(agi::Context*) override { return true; }
+	void OnClick(agi::Context* context) override { func(context); }
+};
+
+class DefaultNormalDynamicMenuItem : public DynamicMenuItem
+{
+	wxString displayName, hotkeyText, help;
+	wxBitmap icon;
+	MenuItemType type;
+	std::function<void(agi::Context*)> func;
+public:
+	DefaultNormalDynamicMenuItem(wxString displayName, wxString hotkeyText, wxString help, wxBitmap icon, MenuItemType type, std::function<void(agi::Context*)> func)
+    : displayName(displayName), hotkeyText(hotkeyText), help(help), icon(icon), type(type), func(func) { }
+	~DefaultNormalDynamicMenuItem() = default;
+	wxString GetDisplayName(agi::Context*) override { return displayName; }
+	wxString GetHotkeyText(agi::Context*) override { return hotkeyText; }
+	wxString GetHelp(agi::Context*) override { return help; }
+	wxBitmap GetIcon(int size, wxLayoutDirection dir = wxLayout_LeftToRight) override { return icon; }
+	bool Validate(agi::Context*) override { return true; }
+	MenuItemType GetMenuItemType() override { return MENU_NORMAL; }
+	bool IsDynamic() override { return false; }
+	bool IsActive(agi::Context*) override { return true; }
+	void OnClick(agi::Context* context) override { func(context); }
+};
+
+class CommandDynamicMenuItem : public DynamicMenuItem
+{
+	cmd::Command* command;
+	wxString overriddenText;
+public:
+	CommandDynamicMenuItem(cmd::Command* command, const wxString overriddenText)
+    : command(command), overriddenText(overriddenText) {}
+	CommandDynamicMenuItem(cmd::Command* command)
+		: command(command), overriddenText("") {}
+	~CommandDynamicMenuItem() = default;
+	wxString GetDisplayName(agi::Context*) override;
+	wxString GetHotkeyText(agi::Context*) override;
+	wxString GetHelp(agi::Context*) override { return command->StrHelp(); }
+	wxBitmap GetIcon(int size, wxLayoutDirection dir = wxLayout_LeftToRight) override { return command->Icon(size, dir); }
+	bool Validate(agi::Context* context) override { return command->Validate(context); }
+	MenuItemType GetMenuItemType() override
+	{
+		return command->Type() & cmd::COMMAND_RADIO ? MENU_RADIO
+			: (command->Type() & cmd::COMMAND_TOGGLE ? MENU_TOGGLE : MENU_NORMAL);
+	}
+	bool IsDynamic() override { return command->Type() != cmd::COMMAND_NORMAL; }
+	bool IsActive(agi::Context* context) override { return command->IsActive(context); }
+	void OnClick(agi::Context* context) override { command->operator()(context); }
+};
+
+class DynamicMenuHelper {
+	std::map<int, std::shared_ptr<DynamicMenuItem>> menuItems;
+	std::map<int, wxMenuItem*> wxMenuItems;
+
+	/// ID allocator for allocating menu item ids.
+	agi::id_allocator* allocator;
+
+	/// Project context
+	agi::Context* context;
+
+	/// Connection for hotkey change signal
+	agi::signal::Connection hotkeys_changed;
+
+	/// Update a single dynamic menu item
+	void UpdateItem(std::shared_ptr<DynamicMenuItem> const& item, wxMenuItem* wxItem);
+	void UpdateItemName(std::shared_ptr<DynamicMenuItem> const& item, wxMenuItem* wxItem);
+    wxMenuItem* CreateItem(std::shared_ptr<DynamicMenuItem> item, wxMenu* parent) const;
+public:
+	using DynamicMenuItemPred = std::function<bool(DynamicMenuItem*)>;
+
+	DynamicMenuHelper(agi::Context* context, agi::id_allocator* allocator);
+	void SetContext(agi::Context* c) {
+		context = c;
+	}
+	/// Append a command to a menu and register the needed handlers
+	int AddMenuItem(std::shared_ptr<DynamicMenuItem> item, wxMenu* parent);
+	/// Prepend a command to a menu and register the needed handlers
+	int PrependMenuItem(std::shared_ptr<DynamicMenuItem> item, wxMenu* parent);
+
+	std::shared_ptr<DynamicMenuItem> FindItem(std::function<bool(DynamicMenuItem*)> pred);
+	wxMenuItem* FindWxItem(DynamicMenuItemPred pred);
+	int FindItemId(DynamicMenuItemPred pred);
+
+	/// Force register id with the given callback.
+	///	USE WITH CARE.
+	///	This should be only used for registering "wxWidgets standard ids" which can't be achieved from ID allocator.
+	void ForceRegisterId(int id, std::shared_ptr<DynamicMenuItem> item);
+	/// Unregister a dynamic menu item
+	///	This frees the id of the item, so
+	///	IMMEDIATELY remove the item from all menus after calling this function to avoid ID conflict.
+	void Remove(wxMenuItem* item);
+	/// Unregister a dynamic menu item
+	///	This frees the id of the item, so
+	///	*IMMEDIATELY* remove the item from all menus after calling this function to avoid ID conflict.
+	void Remove(int id);
+	void Remove(DynamicMenuItemPred pred);
+
+	void OnMenuOpen(wxMenuEvent&);
+	void OnMenuClick(wxCommandEvent& evt);
+	/// Update the hotkeys for all menu items
+	void OnHotkeysChanged();
+
+	void AttachMenu(wxEvtHandler* menu);
+};

--- a/src/include/aegisub/menu_initializer.h
+++ b/src/include/aegisub/menu_initializer.h
@@ -1,0 +1,100 @@
+// Copyright (c) 2019, Charlie Jiang <cqjjjzr@126.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+/// @file menu_initializer.h
+/// @brief Menu initializer tool.
+/// @ingroup menu
+
+#pragma once
+
+#include <boost/any.hpp>
+#include <utility>
+#include <vector>
+#include <initializer_list>
+#include <type_traits>
+
+#include "menu.h"
+
+namespace menu {
+enum MenuNodeType
+{
+    command = 0,
+    submenu = 1,
+    separator = 2,
+    dynamic = 3
+};
+
+enum SpecialMenuNode
+{
+    none = -1,
+    help = 0,
+    options = 1,
+    about = 2,
+    exit = 3,
+    window = 4
+};
+
+DEFINE_EXCEPTION(BadMenuTypeException, agi::Exception);
+
+class MenuNode
+{
+public:
+    MenuNodeType type;
+    boost::any value;
+    SpecialMenuNode special = none;
+    std::string text = "";
+    UpdateableMenu* dynamicMenu = nullptr;
+
+    MenuNode(): type(separator) { }
+    MenuNode(std::string const& commandName): type(command), value(commandName) {}
+    MenuNode(std::string const& commandName, SpecialMenuNode const& special): type(command), value(commandName), special(special) {}
+    MenuNode(std::string const& commandName, std::string commandOverrideText, SpecialMenuNode const& special = none)
+    : type(command), value(commandName), special(special), text(std::move(commandOverrideText)) {}
+    MenuNode(std::string submenuName, std::initializer_list<MenuNode> submenuNodes) : type(submenu),
+        value(std::vector<MenuNode>(submenuNodes)), text(std::move(submenuName)) {}
+    MenuNode(std::string submenuName, std::initializer_list<MenuNode> submenuNodes, SpecialMenuNode const& special) : type(submenu),
+        value(std::vector<MenuNode>(submenuNodes)), special(special), text(std::move(submenuName)){}
+
+    MenuNode(std::string submenuName, UpdateableMenu* dynamicMenu): type(dynamic), dynamicMenu(dynamicMenu), text(std::move(submenuName)) {}
+
+    std::string GetName() const {
+        if (type == submenu || type == dynamic) return text;
+        if (type == command) return boost::any_cast<std::string>(value);
+        return "";
+    }
+
+    std::string GetText() const
+    {
+        return text;
+    }
+
+    wxMenu* GetSubmenu() {
+        return dynamicMenu;
+    }
+
+    std::vector<MenuNode>& GetSubmenuNodes()
+    {
+        if (type == submenu)
+            return boost::any_cast<std::vector<MenuNode>&>(value);
+        throw BadMenuTypeException("Internal error: Bad submenu type!");
+    }
+
+    void UpdateDynamicMenu()
+    {
+        if (type == dynamic)
+            boost::any_cast<UpdateableMenu*>(value)->UpdateMenu();
+    }
+};
+
+}

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -20,27 +20,20 @@
 
 #include "include/aegisub/context.h"
 #include "include/aegisub/hotkey.h"
+#include "include/aegisub/menu_initializer.h"
+#include "include/aegisub/menu_dynamic.h"
 
 #include "auto4_base.h"
 #include "command/command.h"
 #include "compat.h"
 #include "format.h"
 #include "libaegisub/resources.h"
-#include "options.h"
-#include "utils.h"
+#include "menu_dynamic_builtin.h"
 
-#include <libaegisub/cajun/reader.h>
-#include <libaegisub/hotkey.h>
-#include <libaegisub/json.h>
 #include <libaegisub/log.h>
 #include <libaegisub/make_unique.h>
-#include <libaegisub/path.h>
-#include <libaegisub/split.h>
 
-#include <algorithm>
-#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
-#include <boost/locale/collator.hpp>
 #include <vector>
 #include <wx/frame.h>
 #include <wx/menu.h>
@@ -51,357 +44,70 @@
 #endif
 
 namespace {
-/// Window ID of first menu item
-static const int MENU_ID_BASE = 10000;
+void processMenuItem(menu::MenuNode& item, wxMenu* meparentnu, agi::Context* context, DynamicMenuHelper* cm);
+wxMenu* buildMenu(std::vector<menu::MenuNode>& items, agi::Context* c, DynamicMenuHelper* cm, wxMenu* menu = nullptr);
 
-class MruMenu final : public wxMenu {
-	std::string type;
-	std::vector<wxMenuItem *> items;
-	std::vector<std::string> *cmds;
-
-	void Resize(size_t new_size) {
-		for (size_t i = GetMenuItemCount(); i > new_size; --i) {
-			Remove(FindItemByPosition(i - 1));
-		}
-
-		for (size_t i = GetMenuItemCount(); i < new_size; ++i) {
-			if (i >= items.size()) {
-				items.push_back(new wxMenuItem(this, MENU_ID_BASE + cmds->size(), "_"));
-				cmds->push_back(agi::format("recent/%s/%d", boost::to_lower_copy(type), i));
-			}
-			Append(items[i]);
-		}
-	}
-
-public:
-	MruMenu(std::string type, std::vector<std::string> *cmds)
-	: type(std::move(type))
-	, cmds(cmds)
-	{
-	}
-
-	~MruMenu() {
-		// Append all items to ensure that they're all cleaned up
-		Resize(items.size());
-	}
-
-	void Update() {
-		const auto mru = config::mru->Get(type.c_str());
-
-		Resize(mru->size());
-
-		if (mru->empty()) {
-			Resize(1);
-			items[0]->Enable(false);
-			items[0]->SetItemLabel(_("Empty"));
-			return;
-		}
-
-		int i = 0;
-		for (auto it = mru->begin(); it != mru->end(); ++it, ++i) {
-			wxString name = it->wstring();
-			if (!name.StartsWith("?"))
-				name = it->filename().wstring();
-			items[i]->SetItemLabel(fmt_wx("%s%d %s",
-				i <= 9 ? "&" : "", i + 1,
-				name));
-			items[i]->Enable(true);
-		}
-	}
-};
-
-/// @class CommandManager
-/// @brief Event dispatcher to update menus on open and handle click events
-///
-/// Some of what the class does could be dumped off on wx, but wxEVT_MENU_OPEN
-/// is super buggy (GetMenu() often returns nullptr and it outright doesn't trigger
-/// on submenus in many cases, and registering large numbers of wxEVT_UPDATE_UI
-/// handlers makes everything involves events unusably slow.
-class CommandManager {
-	/// Menu items which need to do something on menu open
-	std::vector<std::pair<std::string, wxMenuItem*>> dynamic_items;
-	/// Menu items which need to be updated only when hotkeys change
-	std::vector<std::pair<std::string, wxMenuItem*>> static_items;
-	/// window id -> command map
-	std::vector<std::string> items;
-	/// MRU menus which need to be updated on menu open
-	std::vector<MruMenu*> mru;
-
-	/// Project context
-	agi::Context *context;
-
-	/// Connection for hotkey change signal
-	agi::signal::Connection hotkeys_changed;
-
-	/// Update a single dynamic menu item
-	void UpdateItem(std::pair<std::string, wxMenuItem*> const& item) {
-		cmd::Command *c = cmd::get(item.first);
-		int flags = c->Type();
-		if (flags & cmd::COMMAND_VALIDATE) {
-			item.second->Enable(c->Validate(context));
-			flags = c->Type();
-		}
-		if (flags & cmd::COMMAND_DYNAMIC_NAME)
-			UpdateItemName(item);
-		if (flags & cmd::COMMAND_DYNAMIC_HELP)
-			item.second->SetHelp(c->StrHelp());
-		if (flags & cmd::COMMAND_RADIO || flags & cmd::COMMAND_TOGGLE) {
-			bool check = c->IsActive(context);
-			// Don't call Check(false) on radio items as this causes wxGtk to
-			// send a menu clicked event, and it should be a no-op anyway
-			if (check || flags & cmd::COMMAND_TOGGLE)
-				item.second->Check(check);
-		}
-	}
-
-	void UpdateItemName(std::pair<std::string, wxMenuItem*> const& item) {
-		cmd::Command *c = cmd::get(item.first);
-		wxString text;
-		if (c->Type() & cmd::COMMAND_DYNAMIC_NAME)
-			text = c->StrMenu(context);
-		else
-			text = item.second->GetItemLabel().BeforeFirst('\t');
-		item.second->SetItemLabel(text + to_wx("\t" + hotkey::get_hotkey_str_first("Default", c->name())));
-	}
-
-public:
-	CommandManager(agi::Context *context)
-	: context(context)
-	, hotkeys_changed(hotkey::inst->AddHotkeyChangeListener(&CommandManager::OnHotkeysChanged, this))
-	{
-	}
-
-	void SetContext(agi::Context *c) {
-		context = c;
-	}
-
-	int AddCommand(cmd::Command *co, wxMenu *parent, std::string const& text = "") {
-		return AddCommand(co, parent, text.empty() ? co->StrMenu(context) : _(to_wx(text)));
-	}
-
-	// because wxString doesn't have a move constructor
-	int AddCommand(cmd::Command *co, wxMenu *parent, wxString const& menu_text) {
-		return AddCommand(co, parent, wxString(menu_text));
-	}
-
-	/// Append a command to a menu and register the needed handlers
-	int AddCommand(cmd::Command *co, wxMenu *parent, wxString&& menu_text) {
-		int flags = co->Type();
-		wxItemKind kind =
-			flags & cmd::COMMAND_RADIO ? wxITEM_RADIO :
-			flags & cmd::COMMAND_TOGGLE ? wxITEM_CHECK :
-			wxITEM_NORMAL;
-
-		menu_text += to_wx("\t" + hotkey::get_hotkey_str_first("Default", co->name()));
-
-		wxMenuItem *item = new wxMenuItem(parent, MENU_ID_BASE + items.size(), menu_text, co->StrHelp(), kind);
-#ifndef __WXMAC__
-		/// @todo Maybe make this a configuration option instead?
-		if (kind == wxITEM_NORMAL)
-			item->SetBitmap(co->Icon(16));
-#endif
-		parent->Append(item);
-		items.push_back(co->name());
-
-		if (flags != cmd::COMMAND_NORMAL)
-			dynamic_items.emplace_back(co->name(), item);
-		else
-			static_items.emplace_back(co->name(), item);
-
-		return item->GetId();
-	}
-
-	/// Unregister a dynamic menu item
-	void Remove(wxMenuItem *item) {
-		auto pred = [=](std::pair<std::string, wxMenuItem*> const& o) {
-			return o.second == item;
-		};
-
-		auto it = find_if(dynamic_items.begin(), dynamic_items.end(), pred);
-		if (it != dynamic_items.end())
-			dynamic_items.erase(it);
-		it = find_if(static_items.begin(), static_items.end(), pred);
-		if (it != static_items.end())
-			static_items.erase(it);
-	}
-
-	/// Create a MRU menu and register the needed handlers
-	/// @param name MRU type
-	/// @param parent Menu to append the new MRU menu to
-	void AddRecent(std::string const& name, wxMenu *parent) {
-		mru.push_back(new MruMenu(name, &items));
-		parent->AppendSubMenu(mru.back(), _("&Recent"));
-	}
-
-	void OnMenuOpen(wxMenuEvent &) {
-		if (!context)
-			return;
-		for (auto const& item : dynamic_items) UpdateItem(item);
-		for (auto item : mru) item->Update();
-	}
-
-	void OnMenuClick(wxCommandEvent &evt) {
-		// This also gets clicks on unrelated things such as the toolbar, so
-		// the window ID ranges really need to be unique
-		size_t id = static_cast<size_t>(evt.GetId() - MENU_ID_BASE);
-		if (id < items.size() && context)
-			cmd::call(items[id], context);
-
-#ifdef __WXMAC__
-		else {
-			switch (evt.GetId()) {
-				case wxID_ABOUT:
-					cmd::call("app/about", context);
-					break;
-				case wxID_PREFERENCES:
-					cmd::call("app/options", context);
-					break;
-				case wxID_EXIT:
-					cmd::call("app/exit", context);
-					break;
-				default:
-					break;
-			}
-		}
-#endif
-	}
-
-	/// Update the hotkeys for all menu items
-	void OnHotkeysChanged() {
-		for (auto const& item : dynamic_items) UpdateItemName(item);
-		for (auto const& item : static_items) UpdateItemName(item);
-	}
-};
-
-/// Wrapper for wxMenu to add a command manager
-struct CommandMenu final : public wxMenu {
-	CommandManager cm;
-	CommandMenu(agi::Context *c) : cm(c) { }
-};
-
-/// Wrapper for wxMenuBar to add a command manager
-struct CommandMenuBar final : public wxMenuBar {
-	CommandManager cm;
-	CommandMenuBar(agi::Context *c) : cm(c) { }
-};
-
-/// Read a string from a json object
-/// @param obj Object to read from
-/// @param name Index to read from
-/// @param[out] value Output value to write to
-/// @return Was the requested index found
-bool read_entry(json::Object const& obj, const char *name, std::string *value) {
-	auto it = obj.find(name);
-	if (it == obj.end()) return false;
-	*value = static_cast<json::String const&>(it->second);
-	return true;
-}
-
-/// Get the root object of the menu configuration
-json::Object const& get_menus_root() {
-	static json::Object root;
-	if (!root.empty()) return root;
-
-	try {
-		root = std::move(static_cast<json::Object&>(agi::json_util::file(config::path->Decode("?user/menu.json"), GET_DEFAULT_CONFIG(default_menu))));
-		return root;
-	}
-	catch (json::Reader::ParseException const& e) {
-		LOG_E("menu/parse") << "json::ParseException: " << e.what() << ", Line/offset: " << e.m_locTokenBegin.m_nLine + 1 << '/' << e.m_locTokenBegin.m_nLineOffset + 1;
-		throw;
-	}
-	catch (std::exception const& e) {
-		LOG_E("menu/parse") << e.what();
-		throw;
-	}
-}
-
-/// Get the menu with the specified name
-/// @param name Name of menu to get
-/// @return Array of menu items
-json::Array const& get_menu(std::string const& name) {
-	auto const& root = get_menus_root();
-
-	auto it = root.find(name);
-	if (it == root.end()) throw menu::UnknownMenu("Menu named " + name + " not found");
-	return it->second;
-}
-
-wxMenu *build_menu(std::string const& name, agi::Context *c, CommandManager *cm, wxMenu *menu = nullptr);
-
-/// Recursively process a single entry in the menu json
-/// @param parent Menu to add the item(s) from this entry to
-/// @param c Project context to bind the menu to
-/// @param ele json object to process
-/// @param cm Command manager for this menu
-void process_menu_item(wxMenu *parent, agi::Context *c, json::Object const& ele, CommandManager *cm) {
-	if (ele.empty()) {
-		parent->AppendSeparator();
-		return;
-	}
-
-	std::string submenu, recent, command, text, special;
-	read_entry(ele, "special", &special);
-
-#ifdef __WXMAC__
-	if (special == "window")
-		osx::make_windows_menu(parent);
-#endif
-
-	if (read_entry(ele, "submenu", &submenu) && read_entry(ele, "text", &text)) {
-		wxString tl_text = _(to_wx(text));
-		parent->AppendSubMenu(build_menu(submenu, c, cm), tl_text);
-#ifdef __WXMAC__
-		if (special == "help")
-			wxApp::s_macHelpMenuTitleName = tl_text;
-#endif
-		return;
-	}
-
-	if (read_entry(ele, "recent", &recent)) {
-		cm->AddRecent(recent, parent);
-		return;
-	}
-
-	if (!read_entry(ele, "command", &command))
-		return;
-
-	read_entry(ele, "text", &text);
-
-	try {
-		int id = cm->AddCommand(cmd::get(command), parent, text);
-#ifdef __WXMAC__
-		if (!special.empty()) {
-			if (special == "about")
-				wxApp::s_macAboutMenuItemId = id;
-			else if (special == "exit")
-				wxApp::s_macExitMenuItemId = id;
-			else if (special == "options")
-				wxApp::s_macPreferencesMenuItemId = id;
-		}
-#else
-		(void)id;
-#endif
-	}
-	catch (agi::Exception const& e) {
-#ifdef _DEBUG
-		parent->Append(-1, to_wx(e.GetMessage()))->Enable(false);
-#endif
-		LOG_W("menu/command/not_found") << "Skipping command " << command << ": " << e.GetMessage();
-	}
-}
-
-/// Build the menu with the given name
-/// @param name Name of the menu
-/// @param c Project context to bind the menu to
-wxMenu *build_menu(std::string const& name, agi::Context *c, CommandManager *cm, wxMenu *menu) {
+wxMenu* buildMenu(std::vector<menu::MenuNode>& items, agi::Context* c, DynamicMenuHelper* cm, wxMenu* menu)
+{
 	if (!menu) menu = new wxMenu;
-	for (auto const& item : get_menu(name))
-		process_menu_item(menu, c, item, cm);
+	for (auto& item : items)
+		processMenuItem(item, menu, c, cm);
 	return menu;
 }
 
-class AutomationMenu final : public wxMenu {
+void processMenuItem(menu::MenuNode& item, wxMenu* parent, agi::Context* context, DynamicMenuHelper* cm)
+{
+	auto name = to_wx(item.GetText());
+	try
+	{
+		switch (item.type)
+		{
+		case menu::MenuNodeType::separator:
+			parent->AppendSeparator();
+			return;
+		case menu::MenuNodeType::submenu:
+			parent->AppendSubMenu(buildMenu(item.GetSubmenuNodes(), context, cm), name);
+#ifdef __WXMAC__
+			if (item.special == menu::help)
+				wxApp::s_macHelpMenuTitleName = name;
+#endif
+			return;
+		case menu::MenuNodeType::command:
+		{
+			int id = cm->AddMenuItem(std::make_shared<CommandDynamicMenuItem>(cmd::get(item.GetName()), to_wx(item.GetText())), parent);
+#ifdef __WXMAC__
+			switch (item.special)
+			{
+			case menu::about:
+				wxApp::s_macAboutMenuItemId = id; break;
+			case menu::exit:
+				wxApp::s_macExitMenuItemId = id; break;
+			case menu::options:
+				wxApp::s_macPreferencesMenuItemId = id; break;
+			default: break;
+			}
+#else
+			(void)id; // Disable IDE warning for unused variable.
+#endif
+			return;
+		}
+		case menu::MenuNodeType::dynamic:
+			parent->AppendSubMenu(item.GetSubmenu(), name);
+			return;
+		default:
+#ifdef _DEBUG
+			parent->Append(-1, to_wx("Invalid dynamic menu!"))->Enable(false);
+#endif
+		}
+	} catch (agi::Exception const& e) {
+#ifdef _DEBUG
+		parent->Append(-1, to_wx(e.GetMessage()))->Enable(false);
+#endif
+		LOG_W("menu/command/not_found") << "Skipping command: " << e.GetMessage();
+	}
+}
+
+/*class AutomationMenu final : public wxMenu {
 	agi::Context *c;
 	CommandManager *cm;
 	agi::signal::Connection global_slot;
@@ -494,11 +200,11 @@ public:
 		AppendSeparator();
 		Regenerate();
 	}
-};
+};*/
 }
 
 namespace menu {
-	void GetMenuBar(std::string const& name, wxFrame *window, agi::Context *c) {
+	void AttachMenuBar(MenuProvider provider, wxFrame *window, agi::Context *c, agi::id_allocator* allocator) {
 #ifdef __WXMAC__
 		auto bind_events = [&](CommandMenuBar *menu) {
 			window->Bind(wxEVT_ACTIVATE, [=](wxActivateEvent&) { menu->cm.SetContext(c); });
@@ -514,28 +220,22 @@ namespace menu {
 		}
 #endif
 
-		auto menu = agi::make_unique<CommandMenuBar>(c);
-		for (auto const& item : get_menu(name)) {
-			std::string submenu, disp;
-			read_entry(item, "submenu", &submenu);
-			read_entry(item, "text", &disp);
-			if (!submenu.empty()) {
-				menu->Append(build_menu(submenu, c, &menu->cm), _(to_wx(disp)));
-			}
-			else {
-				read_entry(item, "special", &submenu);
-				if (submenu == "automation")
-					menu->Append(new AutomationMenu(c, &menu->cm), _(to_wx(disp)));
-			}
+		auto menuNode = provider(c);
+
+		auto menu = agi::make_unique<CommandMenuBar>(c, allocator);
+		for (auto& item : menuNode)
+		{
+#ifdef __WXMAC__
+			if (item.special == menu::window)
+				osx::make_windows_menu(parent);
+#endif
+			if (item.type == submenu)
+				menu->Append(buildMenu(item.GetSubmenuNodes(), c, &menu->cm), _(to_wx(item.GetName())));
+			else if (item.type == dynamic)
+				menu->Append(item.GetSubmenu(), _(to_wx(item.GetName())));
 		}
 
-#ifdef __WXMAC__
-		menu->Bind(wxEVT_MENU_OPEN, &CommandManager::OnMenuOpen, &menu->cm);
-		menu->Bind(wxEVT_MENU, &CommandManager::OnMenuClick, &menu->cm);
-#else
-		window->Bind(wxEVT_MENU_OPEN, &CommandManager::OnMenuOpen, &menu->cm);
-		window->Bind(wxEVT_MENU, &CommandManager::OnMenuClick, &menu->cm);
-#endif
+		menu->cm.AttachMenu(menu.get());
 
 #ifdef __WXMAC__
 		bind_events(menu.get());
@@ -547,11 +247,11 @@ namespace menu {
 		menu.release();
 	}
 
-	std::unique_ptr<wxMenu> GetMenu(std::string const& name, agi::Context *c) {
-		auto menu = agi::make_unique<CommandMenu>(c);
-		build_menu(name, c, &menu->cm, menu.get());
-		menu->Bind(wxEVT_MENU_OPEN, &CommandManager::OnMenuOpen, &menu->cm);
-		menu->Bind(wxEVT_MENU, &CommandManager::OnMenuClick, &menu->cm);
+	std::unique_ptr<wxMenu> GetMenu(MenuProvider provider, agi::Context *c, agi::id_allocator* allocator) {
+		auto menu = agi::make_unique<CommandMenu>(c, allocator);
+		auto items = provider(c);
+		buildMenu(items, c, &menu->cm, menu.get());
+		menu->cm.AttachMenu(menu.get());
 		return std::unique_ptr<wxMenu>(menu.release());
 	}
 

--- a/src/menu_builtin.cpp
+++ b/src/menu_builtin.cpp
@@ -1,0 +1,498 @@
+// Copyright (c) 2019, Charlie Jiang <cqjjjzr@126.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// INTERNAL USE
+// Use forward decl to use those functions.
+
+#include "include/aegisub/menu_initializer.h"
+
+#include "menu_dynamic_builtin.h"
+#include "compat.h"
+
+#include <vector>
+#include <string>
+
+std::vector<menu::MenuNode> GetMainMenuWinLinux(agi::Context* context);
+std::vector<menu::MenuNode> GetMainMenuMac(agi::Context* context);
+
+std::vector<menu::MenuNode> GetMainMenu(agi::Context* context)
+{
+#ifdef __WXMAC__
+    return GetMainMenuMac(context);
+#else
+    return GetMainMenuWinLinux(context);
+#endif
+}
+
+std::vector<menu::MenuNode> GetMainMenuWinLinux(agi::Context* context)
+{
+    return std::vector<menu::MenuNode> {
+        {
+            GetTranslation_std("&File"), {
+                { "subtitle/new" },
+                { "subtitle/open" },
+                { "subtitle/open/charset" },
+                { "subtitle/open/video" },
+                { "subtitle/open/autosave" },
+                { "subtitle/save" },
+                { "subtitle/save/as" },
+                { "tool/export" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Subtitle", context) },
+                {},
+                { "subtitle/properties" },
+                { "subtitle/attachment" },
+                { "tool/font_collector" },
+                {},
+                { "app/new_window" },
+                { "app/exit", menu::SpecialMenuNode::exit },
+            }
+        },
+        {
+            GetTranslation_std("&Edit"), {
+                { "edit/undo" },
+                { "edit/redo" },
+                {},
+                { "edit/line/cut" },
+                { "edit/line/copy" },
+                { "edit/line/paste" },
+                { "edit/line/paste/over" },
+                {},
+                { "subtitle/find" },
+                { "subtitle/find/next" },
+                { "edit/find_replace" },
+            }
+        },
+        {
+            GetTranslation_std("&Subtitle"), {
+                { "tool/style/manager" },
+                { "tool/style/assistant" },
+                { "tool/translation_assistant" },
+                { "tool/resampleres" },
+                { "subtitle/spellcheck" },
+                {},
+                { "tool/assdraw" },
+                {
+                    GetTranslation_std("&Insert Lines"), {
+                        { "subtitle/insert/before" },
+                        { "subtitle/insert/after" },
+                        { "subtitle/insert/before/videotime" },
+                        { "subtitle/insert/after/videotime" },
+                    }
+                },
+                { "edit/line/duplicate" },
+                { "edit/line/split/before" },
+                { "edit/line/split/after" },
+                { "edit/line/delete" },
+                {},
+                {
+                    GetTranslation_std("Join Lines"), {
+                        { "edit/line/join/concatenate" },
+                        { "edit/line/join/keep_first" },
+                        { "edit/line/join/as_karaoke" },
+                    }
+                },
+                { "edit/line/recombine" },
+                { "edit/line/split/by_karaoke" },
+                {},
+                {
+                    GetTranslation_std("Sort All Lines"), {
+                        { "grid/sort/start" },
+                        { "grid/sort/end" },
+                        { "grid/sort/style" },
+                        { "grid/sort/actor" },
+                        { "grid/sort/effect" },
+                        { "grid/sort/layer" },
+                    }
+                },
+                {
+                    GetTranslation_std("Sort Selected Lines"), {
+                        { "grid/sort/start/selected" },
+                        { "grid/sort/end/selected" },
+                        { "grid/sort/style/selected" },
+                        { "grid/sort/actor/selected" },
+                        { "grid/sort/effect/selected" },
+                        { "grid/sort/layer/selected" },
+                    }
+                },
+                { "grid/swap" },
+                { "tool/line/select" },
+                { "subtitle/select/all" },
+            }
+        },
+        {
+            GetTranslation_std("&Timing"), {
+                { "time/shift" },
+                { "tool/time/postprocess" },
+                { "tool/time/kanji" },
+                {},
+                { "time/snap/start_video" },
+                { "time/snap/end_video" },
+                { "time/snap/scene" },
+                { "time/frame/current" },
+                {},
+                {
+                    GetTranslation_std("Make Times Continuous"), {
+                        { "time/continuous/start" },
+                        { "time/continuous/end" },
+                    }
+                },
+            }
+        },
+        {
+            GetTranslation_std("&Video"), {
+                { "video/open" },
+                { "video/close" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Video", context) },
+                { "video/open/dummy" },
+                { "video/details" },
+                {},
+                { "timecode/open" },
+                { "timecode/save" },
+                { "timecode/close" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Timecodes", context) },
+                {},
+                { "keyframe/open" },
+                { "keyframe/save" },
+                { "keyframe/close" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Keyframes", context) },
+                {},
+                { "video/detach" },
+                {
+                    GetTranslation_std("Set &Zoom"), {
+                        { "video/zoom/50" },
+                        { "video/zoom/100" },
+                        { "video/zoom/200" },
+                    }
+                },
+                {
+                    GetTranslation_std("Override &AR"), {
+                        { "video/aspect/default" },
+                        { "video/aspect/full" },
+                        { "video/aspect/wide" },
+                        { "video/aspect/cinematic" },
+                        { "video/aspect/custom" },
+                    }
+                },
+                { "video/show_overscan" },
+                {},
+                { "video/jump" },
+                { "video/jump/start" },
+                { "video/jump/end" },
+            }
+        },
+        {
+            GetTranslation_std("&Audio"), {
+                { "audio/open" },
+                { "audio/open/video" },
+                { "audio/close" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Audio", context) },
+                {},
+                { "audio/view/spectrum" },
+                { "audio/view/waveform" },
+                { "audio/open/blank" },
+                { "audio/open/noise" },
+            }
+        },
+        //{ GetTranslation_std("A&utomation"), new menu::AutomationMenu(context) },
+        {
+            GetTranslation_std("Vie&w"), {
+                { "app/language" },
+                { "app/options", menu::SpecialMenuNode::options },
+                {},
+                { "app/display/subs" },
+                { "app/display/video_subs" },
+                { "app/display/audio_subs" },
+                { "app/display/full" },
+                {},
+                { "grid/tags/show" },
+                { "grid/tags/simplify" },
+                { "grid/tags/hide" },
+                {},
+                { "app/toggle/toolbar" },
+            }
+        },
+        {
+            GetTranslation_std("&Help"), {
+                { "help/contents" },
+                {},
+                { "help/website" },
+                { "help/forums" },
+                { "help/bugs" },
+                {},
+                { "help/irc" },
+                { "app/updates" },
+                { "app/about", menu::SpecialMenuNode::about },
+                { "app/log" },
+            }
+        }
+    };
+}
+
+std::vector<menu::MenuNode> GetMainMenuMac(agi::Context* context)
+{
+    return std::vector<menu::MenuNode> {
+        {
+            GetTranslation_std("&File"), {
+                { "subtitle/new", "New" },
+                { "subtitle/open", "Open..." },
+                { "subtitle/open/charset" },
+                { "subtitle/open/video" },
+                { "subtitle/open/autosave" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Subtitle", context) },
+                {},
+                { "subtitle/close" },
+                { "subtitle/save", "Save" },
+                { "subtitle/save/as", "Save As..." },
+                { "tool/export", "Export As..." },
+                {},
+                { "subtitle/properties" },
+                { "subtitle/attachment" },
+                { "tool/font_collector" },
+                {},
+                { "app/exit", menu::SpecialMenuNode::exit },
+            }
+        },
+        {
+            GetTranslation_std("&Edit"), {
+                { "edit/undo" },
+                { "edit/redo" },
+                {},
+                { "edit/line/cut" },
+                { "edit/line/copy" },
+                { "edit/line/paste" },
+                { "edit/line/paste/over" },
+                { "subtitle/select/all" },
+                {},
+                { "subtitle/find" },
+                { "subtitle/find/next" },
+                { "edit/find_replace" },
+                { "subtitle/spellcheck" },
+            }
+        },
+        {
+            GetTranslation_std("Vie&w"), {
+                { "app/language" },
+                { "app/options", menu::SpecialMenuNode::options },
+                {},
+                { "app/display/subs" },
+                { "app/display/video_subs" },
+                { "app/display/audio_subs" },
+                { "app/display/full" },
+                {},
+                { "grid/tags/show" },
+                { "grid/tags/simplify" },
+                { "grid/tags/hide" },
+                {},
+                { "app/toggle/toolbar" },
+            }
+        },
+        {
+            GetTranslation_std("&Subtitle"), {
+                { "tool/style/manager" },
+                { "tool/style/assistant" },
+                { "tool/translation_assistant" },
+                { "tool/resampleres" },
+                {},
+                {
+                    GetTranslation_std("&Insert Lines"), {
+                        { "subtitle/insert/before" },
+                        { "subtitle/insert/after" },
+                        { "subtitle/insert/before/videotime" },
+                        { "subtitle/insert/after/videotime" },
+                    }
+                },
+                { "edit/line/duplicate" },
+                { "edit/line/split/before" },
+                { "edit/line/split/after" },
+                { "edit/line/delete" },
+                {},
+                {
+                    GetTranslation_std("Join Lines"), {
+                        { "edit/line/join/concatenate" },
+                        { "edit/line/join/keep_first" },
+                        { "edit/line/join/as_karaoke" },
+                    }
+                },
+                { "edit/line/recombine" },
+                { "edit/line/split/by_karaoke" },
+                {},
+                {
+                    GetTranslation_std("Sort All Lines"), {
+                        { "grid/sort/start" },
+                        { "grid/sort/end" },
+                        { "grid/sort/style" },
+                        { "grid/sort/actor" },
+                        { "grid/sort/effect" },
+                        { "grid/sort/layer" },
+                    }
+                },
+                {
+                    GetTranslation_std("Sort Selected Lines"), {
+                        { "grid/sort/start/selected" },
+                        { "grid/sort/end/selected" },
+                        { "grid/sort/style/selected" },
+                        { "grid/sort/actor/selected" },
+                        { "grid/sort/effect/selected" },
+                        { "grid/sort/layer/selected" },
+                    }
+                },
+                { "grid/swap" },
+                { "tool/line/select" },
+            }
+        },
+        {
+            GetTranslation_std("&Timing"), {
+                { "time/shift" },
+                { "tool/time/postprocess" },
+                { "tool/time/kanji" },
+                {},
+                { "time/snap/start_video" },
+                { "time/snap/end_video" },
+                { "time/snap/scene" },
+                { "time/frame/current" },
+                {},
+                {
+                    GetTranslation_std("Make Times Continuous"), {
+                        { "time/continuous/start" },
+                        { "time/continuous/end" },
+                    }
+                },
+            }
+        },
+        {
+            GetTranslation_std("&Video"), {
+                { "video/open" },
+                { "video/close" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Video", context) },
+                { "video/open/dummy" },
+                { "video/details" },
+                {},
+                { "timecode/open" },
+                { "timecode/save" },
+                { "timecode/close" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Timecodes", context) },
+                {},
+                { "keyframe/open" },
+                { "keyframe/save" },
+                { "keyframe/close" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Keyframes", context) },
+                {},
+                { "video/detach" },
+                {
+                    GetTranslation_std("Set &Zoom"), {
+                        { "video/zoom/50" },
+                        { "video/zoom/100" },
+                        { "video/zoom/200" },
+                    }
+                },
+                {
+                    GetTranslation_std("Override &AR"), {
+                        { "video/aspect/default" },
+                        { "video/aspect/full" },
+                        { "video/aspect/wide" },
+                        { "video/aspect/cinematic" },
+                        { "video/aspect/custom" },
+                    }
+                },
+                { "video/show_overscan" },
+                {},
+                { "video/jump" },
+                { "video/jump/start" },
+                { "video/jump/end" },
+            }
+        },
+        {
+            GetTranslation_std("&Audio"), {
+                { "audio/open" },
+                { "audio/open/video" },
+                { "audio/close" },
+                { GetTranslation_std("&Recent"), new menu::MruMenu("Audio", context) },
+                {},
+                { "audio/view/spectrum" },
+                { "audio/view/waveform" },
+                { "audio/open/blank" },
+                { "audio/open/noise" },
+            }
+        },
+        //{ GetTranslation_std("A&utomation"), new menu::AutomationMenu(context) },
+        {
+            GetTranslation_std("Window"), {
+                { "app/minimize" },
+                { "app/maximize" },
+                {},
+                { "app/bring_to_front" },
+                {},
+            }, menu::SpecialMenuNode::window
+        },
+        {
+            GetTranslation_std("&Help"), {
+                { "help/contents" },
+                {},
+                { "help/website" },
+                { "help/forums" },
+                { "help/bugs" },
+                {},
+                { "help/irc" },
+                { "app/updates" },
+                { "app/about", menu::SpecialMenuNode::about },
+                { "app/log" },
+            }
+        }
+    };
+}
+
+std::vector<menu::MenuNode> GetVideoContextMenu(agi::Context*)
+{
+    return std::vector<menu::MenuNode> {
+        { "video/frame/save" },
+        { "video/frame/copy" },
+        {},
+        { "video/frame/save/raw" },
+        { "video/frame/copy/raw" },
+        {},
+        { "video/copy_coordinates" }
+    };
+}
+
+std::vector<menu::MenuNode> GetGridContextMenu(agi::Context*)
+{
+    return std::vector<menu::MenuNode>  {
+        { "subtitle/insert/before", "&Insert (before)" },
+        { "subtitle/insert/after", "Insert (after)" },
+        { "subtitle/insert/before/videotime", "Insert at video time (before)" },
+        { "subtitle/insert/after/videotime", "Insert at video time (after)" },
+        {},
+        { "edit/line/duplicate" },
+        { "edit/line/split/before" },
+        { "edit/line/split/after" },
+        {},
+        { "grid/swap" },
+        { "edit/line/join/concatenate", "&Join (concatenate)" },
+        { "edit/line/join/keep_first", "Join (keep first)" },
+        { "edit/line/join/as_karaoke", "Join (as Karaoke)" },
+        {},
+        { "time/continuous/start", "&Make times continuous (change start)" },
+        { "time/continuous/end", "&Make times continuous (change end)" },
+        { "edit/line/recombine" },
+        {},
+        { "audio/save/clip" },
+        {},
+        { "edit/line/cut" },
+        { "edit/line/copy" },
+        { "edit/line/paste" },
+        { "edit/line/paste/over" },
+        {},
+        { "edit/line/delete" }
+    };
+}

--- a/src/menu_dynamic.cpp
+++ b/src/menu_dynamic.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2020, Charlie Jiang <cqjjjzr@126.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#include "include/aegisub/menu_dynamic.h"
+
+#include <libaegisub/hotkey.h>
+#include <libaegisub/id_allocator.h>
+
+#include <algorithm>
+
+#include "include/aegisub/hotkey.h"
+
+wxString CommandDynamicMenuItem::GetDisplayName(agi::Context* context)
+{
+	if (command->Type() & cmd::COMMAND_DYNAMIC_NAME || overriddenText.IsEmpty())
+		return command->StrMenu(context);
+	return overriddenText;
+}
+
+wxString CommandDynamicMenuItem::GetHotkeyText(agi::Context*)
+{
+	return hotkey::get_hotkey_str_first("Default", command->name());
+}
+
+void DynamicMenuHelper::UpdateItem(std::shared_ptr<DynamicMenuItem> const& item, wxMenuItem* wxItem)
+{
+    wxItem->Enable(item->Validate(context));
+	int flags = item->GetMenuItemType();
+	UpdateItemName(item, wxItem);
+	wxItem->SetHelp(item->GetHelp(context));
+	if (flags & MENU_RADIO || flags & MENU_TOGGLE) {
+		bool check = item->IsActive(context);
+		// Don't call Check(false) on radio items as this causes wxGtk to
+		// send a menu clicked event, and it should be a no-op anyway
+		if (check || flags & MENU_TOGGLE)
+			wxItem->Check(check);
+	}
+}
+
+// ReSharper disable once CppMemberFunctionMayBeConst
+// This is NOT const.
+void DynamicMenuHelper::UpdateItemName(std::shared_ptr<DynamicMenuItem> const& item, wxMenuItem* wxItem)
+{
+	wxItem->SetItemLabel(item->GetDisplayName(context) + '\t' + item->GetHotkeyText(context));
+}
+
+wxMenuItem* DynamicMenuHelper::CreateItem(std::shared_ptr<DynamicMenuItem> item, wxMenu* parent) const
+{
+	int flags = item->GetMenuItemType();
+	wxItemKind kind =
+		flags & MENU_RADIO ? wxITEM_RADIO :
+		flags & MENU_TOGGLE ? wxITEM_CHECK :
+		wxITEM_NORMAL;
+
+	wxString menu_text = item->GetDisplayName(context) + '\t' + item->GetHotkeyText(context);
+
+	wxMenuItem* menuItem = new wxMenuItem(parent, allocator->allocate(), menu_text, item->GetHelp(context), kind);
+#ifndef __WXMAC__
+	/// @todo Maybe make this a configuration option instead?
+	if (kind == wxITEM_NORMAL)
+		menuItem->SetBitmap(item->GetIcon(16));
+#endif
+	return menuItem;
+}
+
+DynamicMenuHelper::DynamicMenuHelper(agi::Context* context, agi::id_allocator* allocator)
+{
+	this->allocator = allocator;
+    this->context = context;
+    this->hotkeys_changed = hotkey::inst->AddHotkeyChangeListener(&DynamicMenuHelper::OnHotkeysChanged, this);
+}
+
+int DynamicMenuHelper::AddMenuItem(std::shared_ptr<DynamicMenuItem> item, wxMenu* parent)
+{
+	auto menuItem = CreateItem(item, parent);
+	parent->Append(menuItem);
+	auto id = menuItem->GetId();
+	ForceRegisterId(id, item);
+	wxMenuItems[id] = menuItem;
+	return id;
+}
+
+int DynamicMenuHelper::PrependMenuItem(std::shared_ptr<DynamicMenuItem> item, wxMenu* parent)
+{
+	auto menuItem = CreateItem(item, parent);
+	parent->Prepend(menuItem);
+	auto id = menuItem->GetId();
+	ForceRegisterId(id, item);
+	wxMenuItems[id] = menuItem;
+	return id;
+}
+
+std::shared_ptr<DynamicMenuItem> DynamicMenuHelper::FindItem(std::function<bool(DynamicMenuItem*)> pred)
+{
+	auto result = std::find_if(menuItems.begin(), menuItems.end(), [&](auto& ptr) -> bool { return pred(ptr.second.get()); });
+	if (result != menuItems.end()) return std::shared_ptr(result->second);
+	return std::shared_ptr<DynamicMenuItem>();
+}
+
+wxMenuItem* DynamicMenuHelper::FindWxItem(std::function<bool(DynamicMenuItem*)> pred)
+{
+	auto id = FindItemId(pred);
+	if (id == -1) return nullptr;
+	auto result2 = wxMenuItems.find(id);
+	if (result2 == wxMenuItems.end()) return nullptr;
+	return result2->second;
+}
+
+int DynamicMenuHelper::FindItemId(DynamicMenuItemPred pred)
+{
+	auto result = std::find_if(menuItems.begin(), menuItems.end(), [&](auto& ptr) -> bool { return pred(ptr.second.get()); });
+	if (result == menuItems.end()) return -1;
+	return result->first;
+}
+
+void DynamicMenuHelper::ForceRegisterId(const int id, std::shared_ptr<DynamicMenuItem> item)
+{
+	menuItems[id] = item;
+}
+
+void DynamicMenuHelper::Remove(wxMenuItem* item)
+{
+	Remove(item->GetId());
+}
+
+void DynamicMenuHelper::Remove(int id)
+{
+	menuItems.erase(id);
+	wxMenuItems.erase(id);
+	allocator->free(id);
+}
+
+void DynamicMenuHelper::Remove(DynamicMenuItemPred pred)
+{
+	auto result = std::find_if(menuItems.begin(), menuItems.end(), [&](auto& ptr) -> bool { return pred(ptr.second.get()); });
+	if (result != menuItems.end()) Remove(result->first);
+}
+
+void DynamicMenuHelper::OnMenuOpen(wxMenuEvent& evt)
+{
+	for (auto& item : menuItems)
+		if (item.second->IsDynamic())
+		{
+			auto wxItem = wxMenuItems.find(item.first);
+			if (wxItem != wxMenuItems.end())
+				UpdateItem(item.second, wxItem->second);
+		}
+}
+
+void DynamicMenuHelper::OnMenuClick(wxCommandEvent& evt)
+{
+	auto func = menuItems.find(evt.GetId());
+	if (func != menuItems.end()) func->second->OnClick(context);
+}
+
+void DynamicMenuHelper::OnHotkeysChanged()
+{
+	for (auto& item : menuItems)
+	{
+		auto wxItem = wxMenuItems.find(item.first);
+		if (wxItem != wxMenuItems.end())
+			UpdateItemName(item.second, wxItem->second);
+	}
+}
+
+void DynamicMenuHelper::AttachMenu(wxEvtHandler* menu)
+{
+	menu->Bind(wxEVT_MENU_OPEN, &DynamicMenuHelper::OnMenuOpen, this);
+	menu->Bind(wxEVT_MENU, &DynamicMenuHelper::OnMenuClick, this);
+}

--- a/src/menu_dynamic_builtin.cpp
+++ b/src/menu_dynamic_builtin.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2019, Charlie Jiang <cqjjjzr@126.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+// Aegisub Project http://www.aegisub.org/
+
+#include "menu_dynamic_builtin.h"
+
+#include <libaegisub/mru.h>
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/locale/collator.hpp>
+
+#include "format.h"
+#include "options.h"
+#include "compat.h"
+
+namespace menu
+{
+agi::id_allocator* builtinAllocator = new agi::id_allocator(10000, 50000);
+
+class MruMenuItem : public DynamicMenuItem
+{
+	friend class MruMenu;
+	agi::MRU* mru;
+	agi::fs::path path;
+public:
+	MruMenuItem(agi::MRU* mru, agi::fs::path path): mru(mru), path(path) {}
+    ~MruMenuItem() override {}
+	wxString GetDisplayName(agi::Context*) override { return to_wx(path.string()); }
+	wxString GetHotkeyText(agi::Context*) override { return ""; }
+	wxString GetHelp(agi::Context*) override { return ""; }
+	bool Validate(agi::Context*) override { return true; }
+	MenuItemType GetMenuItemType() override { return MENU_NORMAL; }
+	bool IsDynamic() override { return false; }
+	bool IsActive(agi::Context*) override { return false; }
+    void OnClick(agi::Context* ctx) override
+	{
+		mru->handler(ctx, path);
+	}
+};
+
+void MruMenu::OnMruModification(agi::MruModificationType changeType, std::string const& key, agi::fs::path const& entry)
+{
+	if (key != type) return;
+	switch (changeType)
+	{
+	case agi::MruModificationType::Add:
+		helper.PrependMenuItem(std::make_shared<MruMenuItem>(mru, entry), this);
+		break;
+	case agi::MruModificationType::Remove:
+	    {
+		auto wxmi = helper.FindWxItem([&](DynamicMenuItem* p) -> bool
+		{
+			auto mi = dynamic_cast<MruMenuItem*>(p);
+			if (mi == nullptr) return false;
+			return mi->mru == this->mru && mi->path == entry;
+		});
+		helper.Remove(wxmi);
+		Delete(wxmi);
+	    }
+		break;
+	case agi::MruModificationType::MoveUp:
+	    {
+		auto wxmi = helper.FindWxItem([&](DynamicMenuItem* p) -> bool
+		{
+			auto mi = dynamic_cast<MruMenuItem*>(p);
+			if (mi == nullptr) return false;
+			return mi->mru == this->mru && mi->path == entry;
+		});
+		if (wxmi == nullptr) return;
+		Remove(wxmi);
+		Prepend(wxmi);
+	    }
+		break;
+	}
+}
+
+MruMenu::MruMenu(std::string const& type, agi::Context* ctx)
+    : type(type)
+	, mru(config::mru->GetMRU(this->type))
+    , helper(ctx, builtinAllocator)
+    , c(ctx)
+    , mruModificationConn(config::mru->AddMruModificationListener(&MruMenu::OnMruModification, this))
+{
+	helper.AttachMenu(this);
+	for (auto entry : mru->entries)
+		helper.AddMenuItem(std::make_shared<MruMenuItem>(mru, entry), this);
+}
+
+void MruMenu::UpdateMenu()
+{
+
+}
+
+struct WorkItem {
+	std::string displayname;
+	cmd::Command* command;
+	std::vector<WorkItem> subitems;
+
+	WorkItem(std::string const& displayname, cmd::Command* command = nullptr)
+		: displayname(displayname), command(command) { }
+
+	WorkItem* FindOrMakeSubitem(std::string const& name) {
+		auto sub = std::find_if(subitems.begin(), subitems.end(), [&](WorkItem const& item) { return item.displayname == name; });
+		if (sub != subitems.end()) return &*sub;
+
+		subitems.emplace_back(name);
+		return &subitems.back();
+	}
+
+	void Sort() {
+		if (command) return;
+		for (auto& sub : subitems)
+			sub.Sort();
+		auto comp = boost::locale::comparator<std::string::value_type>();
+		std::sort(subitems.begin(), subitems.end(), [&](WorkItem const& a, WorkItem const& b) {
+			return comp(a.displayname, b.displayname);
+		});
+	}
+
+	void GenerateMenu(wxMenu* parent, AutomationMenu* am) {
+		for (auto item : subitems) {
+			if (item.command) {
+				//am->cm->AddCommand(item.command, parent, item.displayname);
+				//am->all_items.push_back(parent->GetMenuItems().back());
+			}
+			else {
+				auto submenu = new wxMenu;
+				parent->AppendSubMenu(submenu, to_wx(item.displayname));
+				item.GenerateMenu(submenu, am);
+			}
+		}
+	}
+};
+
+}

--- a/src/menu_dynamic_builtin.h
+++ b/src/menu_dynamic_builtin.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2019, Charlie Jiang <cqjjjzr@126.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+/// @file menu_dynamic_builtin.h
+/// @brief Builtin dynamic menus.
+/// @ingroup menu
+
+#pragma once
+
+#include "include/aegisub/menu.h"
+#include <libaegisub/id_allocator.h>
+#include <libaegisub/mru.h>
+
+namespace menu
+{
+extern agi::id_allocator* builtinAllocator;
+
+class MruMenu : public UpdateableMenu
+{
+	std::string type;
+	agi::MRU* mru;
+	DynamicMenuHelper helper;
+	agi::Context* c;
+
+	agi::signal::Connection mruModificationConn;
+	void OnMruModification(agi::MruModificationType changeType, std::string const& key, agi::fs::path const& entry);
+public:
+	MruMenu(std::string const& type, agi::Context* ctx);
+	void UpdateMenu() override;
+};
+
+class AutomationMenu : public UpdateableMenu
+{
+	agi::Context* c;
+	agi::signal::Connection global_slot;
+	agi::signal::Connection local_slot;
+	std::vector<wxMenuItem*> all_items;
+public:
+	void RegenerateMenu();
+	void UpdateMenu() {}
+
+	AutomationMenu(agi::Context* ctxt);
+	~AutomationMenu();
+};
+}

--- a/src/mru_builtin.cpp
+++ b/src/mru_builtin.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2019, Charlie Jiang <cqjjjzr@126.com>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+// Aegisub Project http://www.aegisub.org/
+
+#include <libaegisub/mru.h>
+#include "autoreghook.h"
+#include "include/aegisub/context.h"
+#include "project.h"
+#include "subs_controller.h"
+
+using namespace agi::mru;
+
+namespace
+{
+MRUDescriptor audioDesc{ "Audio",        [](agi::Context* c, auto& path) -> void { c->project->LoadAudio(path); }, "Limits/MRU" };
+MRUDescriptor videoDesc{ "Video",        [](agi::Context* c, auto& path) -> void { c->project->LoadVideo(path); }, "Limits/MRU" };
+MRUDescriptor keyframesDesc{ "Keyframes",[](agi::Context* c, auto& path) -> void { c->project->LoadKeyframes(path); }, "Limits/MRU" };
+MRUDescriptor subtitleDesc{ "Subtitle",  [](agi::Context* c, auto& path) -> void
+{
+	#ifdef __APPLE__
+		wxGetApp().NewProjectContext().project->LoadSubtitles(path);
+#else
+		if (c->subsController->TryToClose() == wxCANCEL) return;
+		c->project->LoadSubtitles(path);
+#endif
+}, "Limits/MRU" };
+MRUDescriptor timecodesDesc{ "Timecodes",[](agi::Context* c, auto& path) -> void { c->project->LoadTimecodes(path); }, "Limits/MRU" };
+MRUDescriptor findDesc{ "Find",          [](agi::Context*, auto&) -> void {}, "Limits/Find Replace" };       // No-op handler
+MRUDescriptor replaceDesc{ "Replace",    [](agi::Context*, auto&) -> void {}, "Limits/Find Replace" };
+}
+
+START_HOOK_BEGIN(mruBuiltin)
+RegisterMRU(audioDesc);
+RegisterMRU(findDesc);
+RegisterMRU(keyframesDesc);
+RegisterMRU(replaceDesc);
+RegisterMRU(subtitleDesc);
+RegisterMRU(timecodesDesc);
+RegisterMRU(videoDesc);
+START_HOOK_END

--- a/src/video_display.cpp
+++ b/src/video_display.cpp
@@ -42,6 +42,7 @@
 #include "include/aegisub/context.h"
 #include "include/aegisub/hotkey.h"
 #include "include/aegisub/menu.h"
+#include "include/aegisub/menu_initializer.h"
 #include "options.h"
 #include "project.h"
 #include "retina_helper.h"
@@ -65,6 +66,11 @@
 #else
 #include <GL/gl.h>
 #endif
+
+namespace menu {
+extern agi::id_allocator* builtinAllocator;
+}
+std::vector<menu::MenuNode> GetVideoContextMenu(agi::Context*);
 
 /// Attribute list for gl canvases; set the canvases to doublebuffered rgba with an 8 bit stencil buffer
 int attribList[] = { WX_GL_RGBA , WX_GL_DOUBLEBUFFER, WX_GL_STENCIL_SIZE, 8, 0 };
@@ -375,7 +381,7 @@ void VideoDisplay::OnMouseWheel(wxMouseEvent& event) {
 }
 
 void VideoDisplay::OnContextMenu(wxContextMenuEvent&) {
-	if (!context_menu) context_menu = menu::GetMenu("video_context", con);
+	if (!context_menu) context_menu = menu::GetMenu(GetVideoContextMenu, con, menu::builtinAllocator);
 	SetCursor(wxNullCursor);
 	menu::OpenPopupMenu(context_menu.get(), this);
 }


### PR DESCRIPTION
1. Use hardcoded menu with initializer (DSL-ish) to create menu, not from JSON(since in the original code there isn't any method to change these menus.).
  So we can flexibly handle dynamic menus and special menus.
2. Added a helper class to handle dynamic menu like MRU and automation.
  A new layer of abstraction.
3. Deprecated the `CommandManager` class.
  The old `CommandManager` is strongly coupled with command system. This make it pain to implement dynamic menus like MRUs and plugin menus.
4. Rewrote the MRU(Most recent used) infrastructure. Uncouple it with the command system.
  Now the code to handle opening requests for MRU entries are moved in to a separate file, not in the `recent.cpp`.
  And also, MRU definitions are no longer hard coded in `libaegisub` module, but registerable and the built-in MRUs are in the `mru_builtin.cpp`.
5. Added a utility to generate wxMenuItem ID. Don't use the silly vector::size() to generate ID!
  Based on intervals.

*[WIP]* The Automation Menu is not complete yet.